### PR TITLE
/tags/tag-name/media/recent supports Count param

### DIFF
--- a/instagram/tags.go
+++ b/instagram/tags.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
+	"strconv"
 )
 
 // TagsService handles communication with the tag related
@@ -61,6 +62,9 @@ func (s *TagsService) RecentMedia(tagName string, opt *Parameters) ([]Media, *Re
 	u := fmt.Sprintf("tags/%v/media/recent", tagName)
 	if opt != nil {
 		params := url.Values{}
+		if opt.Count != 0 {
+			params.Add("count", strconv.FormatUint(opt.Count, 10))
+		}
 		if opt.MinID != "" {
 			params.Add("min_id", opt.MinID)
 		}

--- a/instagram/tags_test.go
+++ b/instagram/tags_test.go
@@ -41,6 +41,7 @@ func TestTagsService_RecentMedia(t *testing.T) {
 		testFormValues(t, r, values{
 			"min_id": "1",
 			"max_id": "1",
+			"count":  "1",
 		})
 		fmt.Fprint(w, `{"data": [{"id":"1"}]}`)
 	})
@@ -48,6 +49,7 @@ func TestTagsService_RecentMedia(t *testing.T) {
 	opt := &Parameters{
 		MinID: "1",
 		MaxID: "1",
+		Count: 1,
 	}
 	media, _, err := client.Tags.RecentMedia("tagname", opt)
 	if err != nil {


### PR DESCRIPTION
Other that MinID and MaxID options, the Count param was not included in
the current implementation. This works now, and returns the exact
number of []Media when opt.Count is included in the request.
