### PR TITLE
Better error handling

### DIFF
--- a/instagram/instagram.go
+++ b/instagram/instagram.go
@@ -388,19 +388,13 @@ func CheckResponse(r *http.Response) error {
 		} else {
 			// Unmarshaling did nothing for us, so the format was not Error{}.
 			// We will assume the format was {Meta: Error{}}:
-			temp := make(map[string]interface{})
+			temp := make(map[string]InstagramError)
 			json.Unmarshal(data, &temp)
 
-			// Convert the meta field to InstagramError
-			if igErr, ok := temp["meta"].(*InstagramError); ok {
-				return igErr
-			} else {
-				return &InstagramError{
-					ErrorType:    "Unknown Error",
-					Code:         0,
-					ErrorMessage: fmt.Sprintf("%v", temp),
-				}
-			}
+			meta := temp["meta"]
+
+			delete(temp, "meta") // Probably uselesss
+			return &meta
 		}
 	}
 

--- a/instagram/tags.go
+++ b/instagram/tags.go
@@ -6,7 +6,7 @@
 package instagram
 
 import (
-	"errors"
+	// "errors"
 	"fmt"
 	"net/url"
 	"regexp"
@@ -82,12 +82,17 @@ func (s *TagsService) RecentMedia(tagName string, opt *Parameters) ([]Media, *Re
 
 	_, err = s.client.Do(req, media)
 	if err != nil {
-		if req != nil && req.URL != nil {
-			return nil, nil, errors.New(fmt.Sprintf("go-instagram Tag.RecentMedia error:%s on URL %s", err.Error(), req.URL.String()))
-		} else {
-			return nil, nil, errors.New(fmt.Sprintf("go-instagram Tag.RecentMedia error:%s on nil URL", err.Error()))
-		}
+		return nil, nil, err
 	}
+	/*
+		if err != nil {
+			if req != nil && req.URL != nil {
+				return nil, nil, errors.New(fmt.Sprintf("go-instagram Tag.RecentMedia error:%s on URL %s", err.Error(), req.URL.String()))
+			} else {
+				return nil, nil, errors.New(fmt.Sprintf("go-instagram Tag.RecentMedia error:%s on nil URL", err.Error()))
+			}
+		}
+	*/
 
 	page := new(ResponsePagination)
 	if s.client.Response.Pagination != nil {


### PR DESCRIPTION
Hi,
i refactored some code to support native errors from Instagram. Now by using type assertion i can check  if the error is an `instagram.InstagramError`. This enables to find rete limit errors such as `OAuthRateLimitException`.

Example:
```go
ig, _ = instagram.NewClient(nil)
_, _, err := ig.Tags.RecentMedia("test", nil)
if igErr, ok := err.(*instagram.InstagramError); ok {
  fmt.Printf("InstagramError %s (%d): %s", igErr.ErrorType, igErr.Code, igErr.ErrorMessage)
}
```