### PR TITLE
Paginate relationships

### DIFF
--- a/instagram/instagram.go
+++ b/instagram/instagram.go
@@ -101,7 +101,7 @@ type Client struct {
 // Parameters specifies the optional parameters to various service's methods.
 type Parameters struct {
 	Count        uint64
-	Coursor      uint64
+	Cursor       uint64
 	MinID        string
 	MaxID        string
 	MinTimestamp int64

--- a/instagram/instagram.go
+++ b/instagram/instagram.go
@@ -199,6 +199,7 @@ type ResponseMeta struct {
 type ResponsePagination struct {
 	NextURL   string `json:"next_url,omitempty"`
 	NextMaxID string `json:"next_max_id,omitempty"`
+	Cursor    string `json:"next_cursor,omitempty"`
 }
 
 // NewClient returns a new Instagram API client. if a nil httpClient is

--- a/instagram/instagram.go
+++ b/instagram/instagram.go
@@ -101,6 +101,7 @@ type Client struct {
 // Parameters specifies the optional parameters to various service's methods.
 type Parameters struct {
 	Count        uint64
+	Coursor      uint64
 	MinID        string
 	MaxID        string
 	MinTimestamp int64

--- a/instagram/instagram.go
+++ b/instagram/instagram.go
@@ -185,6 +185,12 @@ func (r *Response) NextMaxID() string {
 	return p.NextMaxID
 }
 
+// Cursor gets Cursor parameter that can be passed for next request.
+func (r *Response) Cursor() string {
+	p := r.GetPagination()
+	return p.Cursor
+}
+
 // ResponseMeta represents information about the response. If all goes well,
 // only a Code key with value 200 will present. However, sometimes things
 // go wrong, and in that case ErrorType and ErrorMessage are present.

--- a/instagram/relationships.go
+++ b/instagram/relationships.go
@@ -50,8 +50,8 @@ func (s *RelationshipsService) Follows(userID string, opt *Parameters) ([]User, 
 		if opt.Count != 0 {
 			params.Add("count", strconv.FormatUint(opt.Count, 10))
 		}
-		if opt.Cursor != "" {
-			params.Add("cursor", opt.Cursor)
+		if opt.Cursor != 0 {
+			params.Add("cursor", strconv.FormatUint(opt.Cursor, 10))
 		}
 		u += "?" + params.Encode()
 	}
@@ -93,8 +93,8 @@ func (s *RelationshipsService) FollowedBy(userID string, opt *Parameters) ([]Use
 		if opt.Count != 0 {
 			params.Add("count", strconv.FormatUint(opt.Count, 10))
 		}
-		if opt.Cursor != "" {
-			params.Add("cursor", opt.Cursor)
+		if opt.Cursor != 0 {
+			params.Add("cursor", strconv.FormatUint(opt.Cursor, 10))
 		}
 		u += "?" + params.Encode()
 	}

--- a/instagram/relationships.go
+++ b/instagram/relationships.go
@@ -35,12 +35,23 @@ type Relationship struct {
 // passed then it refers to `self` or curret authenticated user.
 //
 // Instagram API docs: http://instagram.com/developer/endpoints/relationships/#get_users_follows
-func (s *RelationshipsService) Follows(userID string) ([]User, *ResponsePagination, error) {
+func (s *RelationshipsService) Follows(userID string, opt *Parameters) ([]User, *ResponsePagination, error) {
 	var u string
 	if userID != "" {
 		u = fmt.Sprintf("users/%v/follows", userID)
 	} else {
 		u = "users/self/follows"
+	}
+
+	if opt != nil {
+		params := url.Values{}
+		if opt.Count != 0 {
+			params.Add("count", strconv.FormatUint(opt.Count, 10))
+		}
+		if opt.Cursor != "" {
+			params.Add("cursor", opt.Cursor)
+		}
+		u += "?" + params.Encode()
 	}
 
 	req, err := s.client.NewRequest("GET", u, "")
@@ -67,12 +78,23 @@ func (s *RelationshipsService) Follows(userID string) ([]User, *ResponsePaginati
 // passed then it refers to `self` or curret authenticated user.
 //
 // Instagram API docs: http://instagram.com/developer/endpoints/relationships/#get_users_followed_by
-func (s *RelationshipsService) FollowedBy(userID string) ([]User, *ResponsePagination, error) {
+func (s *RelationshipsService) FollowedBy(userID string, opt *Parameters) ([]User, *ResponsePagination, error) {
 	var u string
 	if userID != "" {
 		u = fmt.Sprintf("users/%v/followed-by", userID)
 	} else {
 		u = "users/self/followed-by"
+	}
+
+	if opt != nil {
+		params := url.Values{}
+		if opt.Count != 0 {
+			params.Add("count", strconv.FormatUint(opt.Count, 10))
+		}
+		if opt.Cursor != "" {
+			params.Add("cursor", opt.Cursor)
+		}
+		u += "?" + params.Encode()
 	}
 
 	req, err := s.client.NewRequest("GET", u, "")

--- a/instagram/relationships.go
+++ b/instagram/relationships.go
@@ -7,6 +7,8 @@ package instagram
 
 import (
 	"fmt"
+	"net/url"
+	"strconv"
 )
 
 // RelationshipsService handles communication with the user's relationships related

--- a/instagram/relationships_test.go
+++ b/instagram/relationships_test.go
@@ -18,10 +18,17 @@ func TestRelationshipsService_Follows_self(t *testing.T) {
 
 	mux.HandleFunc("/users/self/follows", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testFormValues(t, r, values{
+			"count": "1",
+		})
 		fmt.Fprint(w, `{"data": [{"id":"1"}]}`)
 	})
 
-	users, _, err := client.Relationships.Follows("")
+	opt := &Parameters{
+		Count: 1,
+	}
+
+	users, _, err := client.Relationships.Follows("", opt)
 	if err != nil {
 		t.Errorf("Relationships.Follows returned error: %v", err)
 	}
@@ -38,10 +45,17 @@ func TestRelationshipsService_Follows_userId(t *testing.T) {
 
 	mux.HandleFunc("/users/1/follows", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testFormValues(t, r, values{
+			"count": "1",
+		})
 		fmt.Fprint(w, `{"data": [{"id":"1"}]}`)
 	})
 
-	users, _, err := client.Relationships.Follows("1")
+	opt := &Parameters{
+		Count: 1,
+	}
+
+	users, _, err := client.Relationships.Follows("1", opt)
 	if err != nil {
 		t.Errorf("Relationships.Follows returned error: %v", err)
 	}
@@ -58,10 +72,17 @@ func TestRelationshipsService_FollowedBy_self(t *testing.T) {
 
 	mux.HandleFunc("/users/self/followed-by", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testFormValues(t, r, values{
+			"count": "1",
+		})
 		fmt.Fprint(w, `{"data": [{"id":"1"}]}`)
 	})
 
-	users, _, err := client.Relationships.FollowedBy("")
+	opt := &Parameters{
+		Count: 1,
+	}
+
+	users, _, err := client.Relationships.FollowedBy("", opt)
 	if err != nil {
 		t.Errorf("Relationships.FollowedBy returned error: %v", err)
 	}
@@ -78,10 +99,17 @@ func TestRelationshipsService_FollowedBy_userId(t *testing.T) {
 
 	mux.HandleFunc("/users/1/followed-by", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testFormValues(t, r, values{
+			"count": "1",
+		})
 		fmt.Fprint(w, `{"data": [{"id":"1"}]}`)
 	})
 
-	users, _, err := client.Relationships.FollowedBy("1")
+	opt := &Parameters{
+		Count: 1,
+	}
+
+	users, _, err := client.Relationships.FollowedBy("1", opt)
 	if err != nil {
 		t.Errorf("Relationships.FollowedBy returned error: %v", err)
 	}


### PR DESCRIPTION
I noticed that the method **Follows** and **FollowedBy** didn't support pagination, I added this support, so now you can paginate between people that you follow or people that follows you. It's very simple and uses the same structure than **RecentMedia**, and **ResponsePagination** now returns **Cursor** if this exists. 


	opt := &instagram.Parameters{Count: 20, Cursor: 1232324242}
	users, next, err := client.Relationships.Follows("", opt)
	
	opt := &instagram.Parameters{Count: 20, Cursor: 1232324242}
	users, _, err := client.Relationships.FollowedBy("", opt)
	
	
	
