### PR TITLE
Covering more numeric types for media_count in Tags endpoints.

### DIFF
--- a/instagram/tags.go
+++ b/instagram/tags.go
@@ -66,10 +66,10 @@ func (s *TagsService) RecentMedia(tagName string, opt *Parameters) ([]Media, *Re
 			params.Add("count", strconv.FormatUint(opt.Count, 10))
 		}
 		if opt.MinID != "" {
-			params.Add("min_id", opt.MinID)
+			params.Add("min_tag_id", opt.MinID)
 		}
 		if opt.MaxID != "" {
-			params.Add("max_id", opt.MaxID)
+			params.Add("max_tag_id", opt.MaxID)
 		}
 		u += "?" + params.Encode()
 	}

--- a/instagram/tags.go
+++ b/instagram/tags.go
@@ -23,8 +23,8 @@ type TagsService struct {
 
 // Tag represents information about a tag object.
 type Tag struct {
-	MediaCount int    `json:"media_count,omitempty"`
-	Name       string `json:"name,omitempty"`
+	MediaCount float64 `json:"media_count,omitempty"`
+	Name       string  `json:"name,omitempty"`
 }
 
 // Get information aout a tag object.

--- a/instagram/tags_test.go
+++ b/instagram/tags_test.go
@@ -18,7 +18,7 @@ func TestTagsService_Get(t *testing.T) {
 
 	mux.HandleFunc("/tags/tag-name", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `{"data":{"name": "tag-name"}}`)
+		fmt.Fprint(w, `{"data": {"media_count": 0, "name":"tag-name"}}`)
 	})
 
 	tag, err := client.Tags.Get("tag-name")
@@ -71,7 +71,7 @@ func TestTagsService_Search(t *testing.T) {
 		testFormValues(t, r, values{
 			"q": "tag-name",
 		})
-		fmt.Fprint(w, `{"data": [{"name":"tag-name"}]}`)
+		fmt.Fprint(w, `{"data": [{"media_count": 0.0, "name":"tag-name"}]}`)
 	})
 
 	tags, _, err := client.Tags.Search("tag-name")

--- a/instagram/tags_test.go
+++ b/instagram/tags_test.go
@@ -39,8 +39,8 @@ func TestTagsService_RecentMedia(t *testing.T) {
 	mux.HandleFunc("/tags/tagname/media/recent", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testFormValues(t, r, values{
-			"min_id": "1",
-			"max_id": "1",
+			"min_tag_id": "1",
+			"max_tag_id": "1",
 			"count":  "1",
 		})
 		fmt.Fprint(w, `{"data": [{"id":"1"}]}`)


### PR DESCRIPTION
Addressing issue #13 and #15 
