### PR TITLE
update Cursor to be a string

### DIFF
--- a/instagram/instagram.go
+++ b/instagram/instagram.go
@@ -101,7 +101,7 @@ type Client struct {
 // Parameters specifies the optional parameters to various service's methods.
 type Parameters struct {
 	Count        uint64
-	Cursor       uint64
+	Cursor       string
 	MinID        string
 	MaxID        string
 	MinTimestamp int64

--- a/instagram/relationships.go
+++ b/instagram/relationships.go
@@ -50,8 +50,8 @@ func (s *RelationshipsService) Follows(userID string, opt *Parameters) ([]User, 
 		if opt.Count != 0 {
 			params.Add("count", strconv.FormatUint(opt.Count, 10))
 		}
-		if opt.Cursor != 0 {
-			params.Add("cursor", strconv.FormatUint(opt.Cursor, 10))
+		if opt.Cursor != "" {
+			params.Add("cursor", opt.Cursor)
 		}
 		u += "?" + params.Encode()
 	}
@@ -93,8 +93,8 @@ func (s *RelationshipsService) FollowedBy(userID string, opt *Parameters) ([]Use
 		if opt.Count != 0 {
 			params.Add("count", strconv.FormatUint(opt.Count, 10))
 		}
-		if opt.Cursor != 0 {
-			params.Add("cursor", strconv.FormatUint(opt.Cursor, 10))
+		if opt.Cursor != "" {
+			params.Add("cursor", opt.Cursor)
 		}
 		u += "?" + params.Encode()
 	}


### PR DESCRIPTION
The Cursor object returned from Instagram is a string, so I had to make this update to paginate calls.
